### PR TITLE
Use tsc to build React package.

### DIFF
--- a/packages/steppp-react/package.json
+++ b/packages/steppp-react/package.json
@@ -1,42 +1,41 @@
 {
-    "name": "@ramseyinhouse/steppp-react",
-    "version": "0.0.2",
-    "license": "GPL-3.0",
-    "main": "dist/steppp-react.umd.js",
-    "module": "dist/steppp-react.es.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist/", 
-        "src/"
-    ],
-    "scripts": {
-        "dev": "vite serve example",
-        "build": "vite build && tsc",
-        "serve": "vite preview",
-        "test": "vitest run",
-        "format": "prettier --write \"**/*.{js,ts,css,md}\""
-    },
-    "devDependencies": {
-        "@testing-library/react": "13.4.0",
-        "@types/react": "18.0.27",
-        "@types/react-dom": "18.0.10",
-        "jsdom": "21.1.0",
-        "lint-staged": ">=13.1.0",
-        "prettier": "2.8.3",
-        "terser": "5.16.1",
-        "typescript": "^4.9.4",
-        "vite": "^4.0.4",
-        "vitest": "^0.26.3"
-    },
-    "lint-staged": {
-        "*.{js,ts,css,md}": "prettier --write"
-    },
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@ramseyinhouse/steppp": "*",
-        "react": "18.2.0",
-        "react-dom": "18.2.0"
-    }
+  "name": "@ramseyinhouse/steppp-react",
+  "version": "0.0.3",
+  "license": "GPL-3.0",
+  "main": "dist/steppp-react.umd.js",
+  "module": "dist/steppp-react.es.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/",
+    "src/"
+  ],
+  "scripts": {
+    "dev": "vite serve example",
+    "build": "rm -rf dist && tsc --module es2015",
+    "test": "vitest run",
+    "format": "prettier --write \"**/*.{js,ts,css,md,json}\""
+  },
+  "devDependencies": {
+    "@testing-library/react": "13.4.0",
+    "@types/react": "18.0.27",
+    "@types/react-dom": "18.0.10",
+    "jsdom": "21.1.0",
+    "lint-staged": ">=13.1.0",
+    "prettier": "2.8.3",
+    "terser": "5.16.1",
+    "typescript": "^4.9.4",
+    "vite": "^4.0.4",
+    "vitest": "^0.26.3"
+  },
+  "lint-staged": {
+    "*.{js,ts,css,md}": "prettier --write"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@ramseyinhouse/steppp": "*",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
 }

--- a/packages/steppp-react/tsconfig.json
+++ b/packages/steppp-react/tsconfig.json
@@ -1,10 +1,10 @@
 {
-    "extends": "../../tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "jsx": "react-jsx"
-    },
-    "include": [
-        "./src"
-    ]
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "emitDeclarationOnly": false
+  },
+  "include": ["./src"],
+  "exclude": ["src/**/*.test.tsx", "src/testUtils.ts"]
 }

--- a/packages/steppp-react/vite.config.js
+++ b/packages/steppp-react/vite.config.js
@@ -1,27 +1,8 @@
 import { defineConfig } from "vite";
-import path from "path";
 
 export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: "../../setupTests.js",
-  },
-  build: {
-    minify: "terser",
-    lib: {
-      entry: path.resolve(__dirname, "src/index.tsx"),
-      name: "Steppp",
-      fileName: (format) => `steppp-react.${format}.js`,
-      formats: ["es", "umd"],
-    },
-    rollupOptions: {
-      external: ["react", "react-dom"],
-      output: {
-        globals: {
-          react: "React",
-          "react-dom": "ReactDOM",
-        },
-      },
-    },
   },
 });


### PR DESCRIPTION
Using Vite to build the library was leading to an obscure exception to be thrown in the browser when using with Preact. This change avoids the issue by doing a simple compilation with TypeScript itself. All imports are preserved and no bundle actually occurs, but is instead left to the consuming application.