### PR TITLE
Make animations slimmer by setting initial frame before paint.

### DIFF
--- a/packages/steppp/index.html
+++ b/packages/steppp/index.html
@@ -75,7 +75,7 @@
 
       const element = document.getElementById("steppp");
 
-      Steppp(element, {
+      const { forward, backward } = Steppp(element, {
         frames: {
           enter: [
             { transform: "translateX(0%)" },
@@ -87,6 +87,9 @@
           ],
         },
       });
+
+      document.getElementById("next").addEventListener("click", forward);
+      document.getElementById("backward").addEventListener("click", backward);
     </script>
   </body>
 </html>

--- a/packages/steppp/package.json
+++ b/packages/steppp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ramseyinhouse/steppp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "GPL-3.0",
   "main": "dist/steppp.umd.js",
   "module": "dist/steppp.es.js",


### PR DESCRIPTION
Animations were a little janky because after the "new" step was revealed, there would be a flash between the change to the DOM and the beginning of the animation. This change commits the first frame of the animation in the same turn of the event loop, so nothing visually changes until the next repaint when the animation is triggered.