### PR TITLE
Simplify animation logic to resolve weird side effects.

### DIFF
--- a/packages/steppp/index.html
+++ b/packages/steppp/index.html
@@ -78,8 +78,8 @@
       const { forward, backward } = Steppp(element, {
         frames: {
           enter: [
-            { transform: "translateX(0%)" },
             { transform: "translateX(-100%)" },
+            { transform: "translateX(0%)" },
           ],
           exit: [
             { transform: "translateX(0%)" },

--- a/packages/steppp/package.json
+++ b/packages/steppp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ramseyinhouse/steppp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "GPL-3.0",
   "main": "dist/steppp.umd.js",
   "module": "dist/steppp.es.js",

--- a/packages/steppp/src/utils.ts
+++ b/packages/steppp/src/utils.ts
@@ -1,4 +1,4 @@
-import { BuildAnimationArgs, Direction } from "./types";
+import { BuildAnimationArgs } from "./types";
 
 const defaults: KeyframeAnimationOptions = {
   easing: "ease",
@@ -53,12 +53,4 @@ export const afterRepaint = (cb: () => any): void => {
       cb();
     });
   });
-};
-
-export const isMovingBackward = (direction: Direction): boolean => {
-  return direction === "backward";
-};
-
-export const flip = (items: any[]): any[] => {
-  return [...items].reverse();
 };


### PR DESCRIPTION
When updating the React component, I caught some odd edge cases with going _backward_ in the flow. This PR simplifies some of the logic used when determining how to position the frames.